### PR TITLE
Correcting ResourceRecortTtl to Number from Text

### DIFF
--- a/docs/ext_docs/handlers/aws-route53.md
+++ b/docs/ext_docs/handlers/aws-route53.md
@@ -45,7 +45,7 @@ Specifies the time-to-live (TTL) in seconds of the RR (defaults to 300)
 | | |
 |-|-|
 | **Name:**          | `ResourceRecordTtl`
-| **Type:**          | TEXT
+| **Type:**          | INT
 | **IsRequired:**    | False
 | **IsMultiValued:** | False
 


### PR DESCRIPTION
Was receiving InvalidCastException when trying to pass ResourceRecordTtl a string, but the command succeeded when passed a number (INT).